### PR TITLE
resetcontrol: Remove shiphold polarity control

### DIFF
--- a/src/components/SystemFeatures/ResetControl.tsx
+++ b/src/components/SystemFeatures/ResetControl.tsx
@@ -31,11 +31,6 @@ const timerShipToActiveItems = TimeToActiveValues.map(item => ({
     value: `${item}`,
 }));
 
-const invPolarityItems = [true, false].map(item => ({
-    value: `${item}`,
-    label: `${item ? 'Active High' : 'Active Low'}`,
-}));
-
 const card = 'resetControl';
 
 export default ({ npmDevice, ship, disabled }: GPIOProperties) => (
@@ -46,23 +41,6 @@ export default ({ npmDevice, ship, disabled }: GPIOProperties) => (
             </div>
         }
     >
-        <Dropdown
-            label={
-                <DocumentationTooltip card={card} item="SHPHLDPinPolarity">
-                    SHPHLD pin polarity
-                </DocumentationTooltip>
-            }
-            items={invPolarityItems}
-            onSelect={item =>
-                npmDevice.setShipInvertPolarity(item.value === 'true')
-            }
-            disabled={disabled}
-            selectedItem={
-                invPolarityItems.find(
-                    item => item.value === `${ship.invPolarity}`
-                ) ?? invPolarityItems[0]
-            }
-        />
         <Toggle
             label={
                 <DocumentationTooltip card={card} item="LongPressReset">

--- a/src/features/pmicControl/npm/npm1300/pmic1300Device.tsx
+++ b/src/features/pmicControl/npm/npm1300/pmic1300Device.tsx
@@ -758,9 +758,6 @@ export const getNPM1300: INpmDevice = (shellParser, dialogHandler) => {
                         await shipModeSet.setShipModeTimeToActive(
                             config.ship.timeToActive
                         );
-                        await shipModeSet.setShipInvertPolarity(
-                            config.ship.invPolarity
-                        );
                         await shipModeSet.setShipLongPressReset(
                             config.ship.longPressReset
                         );

--- a/src/features/pmicControl/npm/npm1300/shipMode/shipModeCallbacks.ts
+++ b/src/features/pmicControl/npm/npm1300/shipMode/shipModeCallbacks.ts
@@ -44,36 +44,6 @@ export default (
 
         cleanupCallbacks.push(
             shellParser.registerCommandCallback(
-                toRegex('npmx ship config inv_polarity', true),
-                res => {
-                    eventEmitter.emitPartialEvent<ShipModeConfig>(
-                        'onShipUpdate',
-                        {
-                            invPolarity: parseToBoolean(res),
-                        }
-                    );
-                },
-                noop
-            )
-        );
-
-        cleanupCallbacks.push(
-            shellParser.registerCommandCallback(
-                toRegex('npmx ship config inv_polarity', true),
-                res => {
-                    eventEmitter.emitPartialEvent<ShipModeConfig>(
-                        'onShipUpdate',
-                        {
-                            invPolarity: parseToBoolean(res),
-                        }
-                    );
-                },
-                noop
-            )
-        );
-
-        cleanupCallbacks.push(
-            shellParser.registerCommandCallback(
                 toRegex('npmx ship reset long_press', true),
                 res => {
                     eventEmitter.emitPartialEvent<ShipModeConfig>(

--- a/src/features/pmicControl/npm/npm1300/shipMode/shipModeEffects.ts
+++ b/src/features/pmicControl/npm/npm1300/shipMode/shipModeEffects.ts
@@ -15,7 +15,6 @@ export const shipModeGet = (
     ) => void
 ) => ({
     shipModeTimeToActive: () => sendCommand(`npmx ship config time get`),
-    shipInvertPolarity: () => sendCommand(`npmx ship config inv_polarity get`),
     shipLongPressReset: () => sendCommand(`npmx ship reset long_press get`),
     shipTwoButtonReset: () => sendCommand(`npmx ship reset two_buttons get`),
 });
@@ -29,12 +28,8 @@ export const shipModeSet = (
     ) => void,
     offlineMode: boolean
 ) => {
-    const {
-        shipModeTimeToActive,
-        shipInvertPolarity,
-        shipLongPressReset,
-        shipTwoButtonReset,
-    } = shipModeGet(sendCommand);
+    const { shipModeTimeToActive, shipLongPressReset, shipTwoButtonReset } =
+        shipModeGet(sendCommand);
 
     const setShipModeTimeToActive = (timeToActive: TimeToActive) =>
         new Promise<void>((resolve, reject) => {
@@ -49,25 +44,6 @@ export const shipModeSet = (
                     () => resolve(),
                     () => {
                         shipModeTimeToActive();
-                        reject();
-                    }
-                );
-            }
-        });
-
-    const setShipInvertPolarity = (enabled: boolean) =>
-        new Promise<void>((resolve, reject) => {
-            if (offlineMode) {
-                eventEmitter.emitPartialEvent<ShipModeConfig>('onShipUpdate', {
-                    invPolarity: enabled,
-                });
-                resolve();
-            } else {
-                sendCommand(
-                    `npmx ship config inv_polarity set ${enabled ? '1' : '0'}`,
-                    () => resolve(),
-                    () => {
-                        shipInvertPolarity();
                         reject();
                     }
                 );
@@ -114,7 +90,6 @@ export const shipModeSet = (
 
     return {
         setShipModeTimeToActive,
-        setShipInvertPolarity,
         setShipLongPressReset,
         setShipTwoButtonReset,
         enterShipMode: () => sendCommand(`npmx ship mode ship`),

--- a/src/features/pmicControl/npm/npm1300/tests/commandCallbacks.test.ts
+++ b/src/features/pmicControl/npm/npm1300/tests/commandCallbacks.test.ts
@@ -1333,32 +1333,6 @@ Battery models stored in database:
                 },
             ])
             .flat()
-    )('npmx ship config inv_polarity %p', ({ append, enable }) => {
-        const command = `npmx ship config inv_polarity ${append}`;
-        const callback =
-            eventHandlers.mockRegisterCommandCallbackHandler(command);
-
-        callback?.onSuccess(`Value: ${enable ? '1' : '0'}.`, command);
-
-        expect(mockOnShipUpdate).toBeCalledTimes(1);
-        expect(mockOnShipUpdate).toBeCalledWith({
-            invPolarity: enable,
-        });
-    });
-
-    test.each(
-        [true, false]
-            .map(enable => [
-                {
-                    append: `get`,
-                    enable,
-                },
-                {
-                    append: `set ${enable ? '1' : '0'}`,
-                    enable,
-                },
-            ])
-            .flat()
     )('npmx ship reset long_press %p', ({ append, enable }) => {
         const command = `npmx ship reset long_press ${append}`;
         const callback =

--- a/src/features/pmicControl/npm/npm1300/tests/exportImport.test.ts
+++ b/src/features/pmicControl/npm/npm1300/tests/exportImport.test.ts
@@ -361,7 +361,7 @@ describe('PMIC 1300 - Apply Config ', () => {
         expect(mockOnGpioUpdate).toBeCalledTimes(25);
         expect(mockOnLEDUpdate).toBeCalledTimes(3);
         expect(mockOnPOFUpdate).toBeCalledTimes(3);
-        expect(mockOnShipUpdate).toBeCalledTimes(4);
+        expect(mockOnShipUpdate).toBeCalledTimes(3);
         expect(mockOnTimerConfigUpdate).toBeCalledTimes(3);
 
         expect(mockOnFuelGaugeUpdate).toBeCalledTimes(1);

--- a/src/features/pmicControl/npm/npm1300/tests/offlineSetters.test.ts
+++ b/src/features/pmicControl/npm/npm1300/tests/offlineSetters.test.ts
@@ -395,13 +395,6 @@ describe('PMIC 1300 - Setters Offline tests', () => {
         expect(mockOnShipUpdate).toBeCalledWith({ timeToActive: 16 });
     });
 
-    test('Set set timer config inv_polarity ', async () => {
-        await pmic.setShipInvertPolarity(false);
-
-        expect(mockOnShipUpdate).toBeCalledTimes(1);
-        expect(mockOnShipUpdate).toBeCalledWith({ invPolarity: false });
-    });
-
     test('Set set timer reset long_press ', async () => {
         await pmic.setShipLongPressReset(false);
 

--- a/src/features/pmicControl/npm/npm1300/tests/onlineSetters.test.ts
+++ b/src/features/pmicControl/npm/npm1300/tests/onlineSetters.test.ts
@@ -1220,24 +1220,6 @@ describe('PMIC 1300 - Setters Online tests', () => {
         });
 
         test.each([true, false])(
-            'Set ship config inv_polarity %p',
-            async enabled => {
-                await pmic.setShipInvertPolarity(enabled);
-
-                expect(mockEnqueueRequest).toBeCalledTimes(1);
-                expect(mockEnqueueRequest).toBeCalledWith(
-                    `npmx ship config inv_polarity set ${enabled ? '1' : '0'}`,
-                    expect.anything(),
-                    undefined,
-                    true
-                );
-
-                // Updates should only be emitted when we get response
-                expect(mockOnShipUpdate).toBeCalledTimes(0);
-            }
-        );
-
-        test.each([true, false])(
             'Set ship reset long_press %p',
             async enabled => {
                 await pmic.setShipLongPressReset(enabled);
@@ -3094,41 +3076,6 @@ describe('PMIC 1300 - Setters Online tests', () => {
             // Updates should only be emitted when we get response
             expect(mockOnShipUpdate).toBeCalledTimes(0);
         });
-
-        test.each([true, false])(
-            'Set setShipInvertPolarity - Fail immediately - index: %p',
-            async enabled => {
-                mockDialogHandler.mockImplementationOnce(
-                    (dialog: PmicDialog) => {
-                        dialog.onConfirm();
-                    }
-                );
-
-                await expect(
-                    pmic.setShipInvertPolarity(enabled)
-                ).rejects.toBeUndefined();
-
-                expect(mockEnqueueRequest).toBeCalledTimes(2);
-                expect(mockEnqueueRequest).toBeCalledWith(
-                    `npmx ship config inv_polarity set ${enabled ? '1' : '0'}`,
-                    expect.anything(),
-                    undefined,
-                    true
-                );
-
-                // Refresh data due to error
-                expect(mockEnqueueRequest).nthCalledWith(
-                    2,
-                    `npmx ship config inv_polarity get`,
-                    expect.anything(),
-                    undefined,
-                    true
-                );
-
-                // Updates should only be emitted when we get response
-                expect(mockOnShipUpdate).toBeCalledTimes(0);
-            }
-        );
 
         test.each([true, false])(
             'Set setShipLongPressReset - Fail immediately - index: %p',

--- a/src/features/pmicControl/npm/npm1300/tests/requestUpdates.test.ts
+++ b/src/features/pmicControl/npm/npm1300/tests/requestUpdates.test.ts
@@ -598,18 +598,6 @@ describe('PMIC 1300 - Request update commands', () => {
         );
     });
 
-    test('Request update shipInvertPolarity', () => {
-        pmic.requestUpdate.shipInvertPolarity();
-
-        expect(mockEnqueueRequest).toBeCalledTimes(1);
-        expect(mockEnqueueRequest).toBeCalledWith(
-            `npmx ship config inv_polarity get`,
-            expect.anything(),
-            undefined,
-            true
-        );
-    });
-
     test('Request update shipLongPressReset', () => {
         pmic.requestUpdate.shipLongPressReset();
 

--- a/src/features/pmicControl/npm/types.ts
+++ b/src/features/pmicControl/npm/types.ts
@@ -459,7 +459,6 @@ export type NpmDevice = {
         timerConfigPeriod: () => void;
 
         shipModeTimeToActive: () => void;
-        shipInvertPolarity: () => void;
         shipLongPressReset: () => void;
         shipTwoButtonReset: () => void;
 
@@ -532,7 +531,6 @@ export type NpmDevice = {
     setTimerConfigPeriod: (period: number) => Promise<void>;
 
     setShipModeTimeToActive: (time: TimeToActive) => Promise<void>;
-    setShipInvertPolarity: (state: boolean) => Promise<void>;
     setShipLongPressReset: (state: boolean) => Promise<void>;
     setShipTwoButtonReset: (state: boolean) => Promise<void>;
 

--- a/src/features/pmicControl/npm/useNpmDevice.tsx
+++ b/src/features/pmicControl/npm/useNpmDevice.tsx
@@ -172,7 +172,6 @@ export default () => {
             npmDevice.requestUpdate.timerConfigPrescaler();
 
             npmDevice.requestUpdate.shipModeTimeToActive();
-            npmDevice.requestUpdate.shipInvertPolarity();
             npmDevice.requestUpdate.shipLongPressReset();
             npmDevice.requestUpdate.shipTwoButtonReset();
 


### PR DESCRIPTION
Shiphold is always active low and its polarity cannot be configured. Related controls, functions and tests have been removed.