### PR TITLE
NCD-827: Refactor init and request update for nPM1300

### DIFF
--- a/src/features/pmicControl/npm/npm1300/buck/index.ts
+++ b/src/features/pmicControl/npm/npm1300/buck/index.ts
@@ -6,10 +6,45 @@
 
 import { ShellParser } from '@nordicsemiconductor/pc-nrfconnect-shared';
 
+import { RangeType } from '../../../../../utils/helpers';
 import { NpmEventEmitter } from '../../pmicHelpers';
-import { PmicDialog } from '../../types';
+import { Buck, PmicDialog } from '../../types';
 import buckCallbacks from './buckCallbacks';
 import { buckGet, buckSet } from './buckEffects';
+
+export const buckDefaults = (noOfBucks: number): Buck[] => {
+    const defaultBucks: Buck[] = [];
+    for (let i = 0; i < noOfBucks; i += 1) {
+        defaultBucks.push({
+            vOutNormal: getBuckVoltageRange(i).min,
+            vOutRetention: 1,
+            mode: 'vSet',
+            enabled: true,
+            modeControl: 'Auto',
+            onOffControl: 'Off',
+            retentionControl: 'Off',
+            activeDischarge: false,
+        });
+    }
+
+    return defaultBucks;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const getBuckVoltageRange = (i: number) =>
+    ({
+        min: 1,
+        max: 3.3,
+        decimals: 1,
+    } as RangeType);
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const getBuckRetVOutRange = (i: number) =>
+    ({
+        min: 1,
+        max: 3,
+        decimals: 1,
+    } as RangeType);
 
 export default (
     shellParser: ShellParser | undefined,
@@ -27,16 +62,7 @@ export default (
     buckSet: buckSet(eventEmitter, sendCommand, dialogHandler, offlineMode),
     buckCallbacks: buckCallbacks(shellParser, eventEmitter, noOfBucks),
     buckRanges: {
-        getBuckVoltageRange: () => ({
-            min: 1,
-            max: 3.3,
-            decimals: 1,
-        }),
-
-        getBuckRetVOutRange: () => ({
-            min: 1,
-            max: 3,
-            decimals: 1,
-        }),
+        getBuckVoltageRange,
+        getBuckRetVOutRange,
     },
 });

--- a/src/features/pmicControl/npm/npm1300/charger/index.ts
+++ b/src/features/pmicControl/npm/npm1300/charger/index.ts
@@ -8,23 +8,51 @@ import { ShellParser } from '@nordicsemiconductor/pc-nrfconnect-shared';
 
 import { getRange } from '../../../../../utils/helpers';
 import { NpmEventEmitter } from '../../pmicHelpers';
+import { Charger } from '../../types';
 import chargerCallbacks from './chargerCallbacks';
 import { chargerGet, chargerSet } from './chargerEffects';
 
+export const chargerDefaults = (): Charger => ({
+    vTerm: chargerVoltageRange[0],
+    vTrickleFast: 2.5,
+    iChg: chargerCurrentRange.min,
+    enabled: false,
+    iTerm: '10%',
+    enableRecharging: false,
+    enableVBatLow: false,
+    ntcThermistor: '10 kΩ',
+    ntcBeta: 3380,
+    tChgStop: 110,
+    tChgResume: 100,
+    vTermR: 3.6,
+    tCold: 0,
+    tCool: 10,
+    tWarm: 45,
+    tHot: 60,
+});
+
+const chargerVoltageRange = getRange([
+    {
+        min: 3.5,
+        max: 3.65,
+        step: 0.05,
+    },
+    {
+        min: 4.0,
+        max: 4.45,
+        step: 0.05,
+    },
+]).map(v => Number(v.toFixed(2)));
+
+const chargerCurrentRange = {
+    min: 32,
+    max: 800,
+    decimals: 0,
+    step: 2,
+};
+
 const chargerRanges = () => ({
-    getChargerVoltageRange: () =>
-        getRange([
-            {
-                min: 3.5,
-                max: 3.65,
-                step: 0.05,
-            },
-            {
-                min: 4.0,
-                max: 4.45,
-                step: 0.05,
-            },
-        ]).map(v => Number(v.toFixed(2))),
+    getChargerVoltageRange: () => chargerVoltageRange,
     getChargerVTermRRange: () =>
         getRange([
             {
@@ -46,12 +74,7 @@ const chargerRanges = () => ({
         min: 50,
         max: 110,
     }),
-    getChargerCurrentRange: () => ({
-        min: 32,
-        max: 800,
-        decimals: 0,
-        step: 2,
-    }),
+    getChargerCurrentRange: () => chargerCurrentRange,
     getChargerNTCBetaRange: () => ({
         min: 0,
         max: 4294967295,

--- a/src/features/pmicControl/npm/npm1300/gpio/index.ts
+++ b/src/features/pmicControl/npm/npm1300/gpio/index.ts
@@ -7,8 +7,23 @@
 import { ShellParser } from '@nordicsemiconductor/pc-nrfconnect-shared';
 
 import { NpmEventEmitter } from '../../pmicHelpers';
+import { GPIO } from '../../types';
 import gpioCallbacks from './gpioCallbacks';
 import { gpioGet, gpioSet } from './gpioEffects';
+
+export const gpioDefaults = (noOfGpios: number): GPIO[] => {
+    const defaultGPIOs: GPIO[] = [];
+    for (let i = 0; i < noOfGpios; i += 1) {
+        defaultGPIOs.push({
+            mode: 'Input',
+            pull: 'Pull up',
+            drive: 1,
+            openDrain: false,
+            debounce: false,
+        });
+    }
+    return defaultGPIOs;
+};
 
 export default (
     shellParser: ShellParser | undefined,

--- a/src/features/pmicControl/npm/npm1300/ldo/index.ts
+++ b/src/features/pmicControl/npm/npm1300/ldo/index.ts
@@ -6,10 +6,36 @@
 
 import { ShellParser } from '@nordicsemiconductor/pc-nrfconnect-shared';
 
+import { RangeType } from '../../../../../utils/helpers';
 import { NpmEventEmitter } from '../../pmicHelpers';
-import { PmicDialog } from '../../types';
+import { Ldo, PmicDialog } from '../../types';
 import ldoCallbacks from './ldoCallbacks';
 import { ldoGet, ldoSet } from './ldoEffects';
+
+export const ldoDefaults = (noOfLdos: number): Ldo[] => {
+    const defaultLDOs: Ldo[] = [];
+    for (let i = 0; i < noOfLdos; i += 1) {
+        defaultLDOs.push({
+            voltage: getLdoVoltageRange(i).min,
+            mode: 'ldoSwitch',
+            enabled: false,
+            softStartEnabled: true,
+            softStart: 20,
+            activeDischarge: false,
+            onOffControl: 'SW',
+        });
+    }
+    return defaultLDOs;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const getLdoVoltageRange = (i: number) =>
+    ({
+        min: 1,
+        max: 3.3,
+        decimals: 1,
+        step: 0.1,
+    } as RangeType);
 
 export default (
     shellParser: ShellParser | undefined,
@@ -27,11 +53,6 @@ export default (
     ldoSet: ldoSet(eventEmitter, sendCommand, dialogHandler, offlineMode),
     ldoCallbacks: ldoCallbacks(shellParser, eventEmitter, noOfBucks),
     ldoRanges: {
-        getLdoVoltageRange: () => ({
-            min: 1,
-            max: 3.3,
-            decimals: 1,
-            step: 0.1,
-        }),
+        getLdoVoltageRange,
     },
 });

--- a/src/features/pmicControl/npm/npm1300/pmic1300Device.tsx
+++ b/src/features/pmicControl/npm/npm1300/pmic1300Device.tsx
@@ -583,6 +583,17 @@ export const getNPM1300: INpmDevice = (shellParser, dialogHandler) => {
             }
         });
 
+    // Return a set of default LED settings
+    const ledDefaults = (noOfLeds: number): LED[] => {
+        const defaultLEDs: LED[] = [];
+        for (let i = 0; i < noOfLeds; i += 1) {
+            defaultLEDs.push({
+                mode: LEDModeValues[i],
+            });
+        }
+        return defaultLEDs;
+    };
+
     const requestUpdate = {
         all: () => {
             // Request all updates for nPM1300

--- a/src/features/pmicControl/npm/npm1300/pmic1300Device.tsx
+++ b/src/features/pmicControl/npm/npm1300/pmic1300Device.tsx
@@ -36,11 +36,11 @@ import {
     USBDetectStatusValues,
     USBPower,
 } from '../types';
-import setupBucks from './buck';
-import setupCharger from './charger';
+import setupBucks, { buckDefaults } from './buck';
+import setupCharger, { chargerDefaults as chargerDefault } from './charger';
 import setupFuelGauge from './fuelGauge';
-import setupGpio from './gpio';
-import setupLdo from './ldo';
+import setupGpio, { gpioDefaults } from './gpio';
+import setupLdo, { ldoDefaults } from './ldo';
 import setupPof from './pof';
 import setupShipMode from './shipMode';
 import setupTimer from './timer';
@@ -982,5 +982,12 @@ export const getNPM1300: INpmDevice = (shellParser, dialogHandler) => {
             }
             autoReboot = v;
         },
+
+        // Default settings
+        buckDefaults: () => buckDefaults(devices.noOfBucks),
+        ldoDefaults: () => ldoDefaults(devices.noOfLdos),
+        gpioDefaults: () => gpioDefaults(devices.noOfGPIOs),
+        ledDefaults: () => ledDefaults(devices.noOfLEDs),
+        chargerDefault: () => chargerDefault(),
     };
 };

--- a/src/features/pmicControl/npm/npm1300/pmic1300Device.tsx
+++ b/src/features/pmicControl/npm/npm1300/pmic1300Device.tsx
@@ -584,6 +584,80 @@ export const getNPM1300: INpmDevice = (shellParser, dialogHandler) => {
         });
 
     const requestUpdate = {
+        all: () => {
+            // Request all updates for nPM1300
+
+            requestUpdate.usbPowered();
+
+            if (devices.charger) {
+                requestUpdate.chargerVTerm();
+                requestUpdate.chargerIChg();
+                requestUpdate.chargerEnabled();
+                requestUpdate.chargerVTrickleFast();
+                requestUpdate.chargerITerm();
+                requestUpdate.chargerBatLim();
+                requestUpdate.chargerEnabledRecharging();
+                requestUpdate.chargerEnablevBatLow();
+                requestUpdate.pmicChargingState();
+                requestUpdate.chargerNTCThermistor();
+                requestUpdate.chargerNTCBeta();
+                requestUpdate.chargerTChgStop();
+                requestUpdate.chargerTChgResume();
+                requestUpdate.chargerVTermR();
+                requestUpdate.chargerTCold();
+                requestUpdate.chargerTCool();
+                requestUpdate.chargerTWarm();
+                requestUpdate.chargerTHot();
+            }
+
+            for (let i = 0; i < devices.noOfBucks; i += 1) {
+                requestUpdate.buckVOutNormal(i);
+                requestUpdate.buckVOutRetention(i);
+                requestUpdate.buckMode(i);
+                requestUpdate.buckEnabled(i);
+                requestUpdate.buckModeControl(i);
+                requestUpdate.buckOnOffControl(i);
+                requestUpdate.buckActiveDischarge(i);
+            }
+
+            for (let i = 0; i < devices.noOfLdos; i += 1) {
+                requestUpdate.ldoVoltage(i);
+                requestUpdate.ldoMode(i);
+                requestUpdate.ldoEnabled(i);
+                requestUpdate.ldoSoftStartEnabled(i);
+                requestUpdate.ldoSoftStart(i);
+                requestUpdate.ldoActiveDischarge(i);
+                requestUpdate.ldoOnOffControl(i);
+            }
+
+            for (let i = 0; i < devices.noOfGPIOs; i += 1) {
+                requestUpdate.gpioMode(i);
+                requestUpdate.gpioPull(i);
+                requestUpdate.gpioDrive(i);
+                requestUpdate.gpioOpenDrain(i);
+                requestUpdate.gpioDebounce(i);
+            }
+
+            for (let i = 0; i < devices.noOfLEDs; i += 1) {
+                requestUpdate.ledMode(i);
+            }
+            requestUpdate.pofEnable();
+            requestUpdate.pofPolarity();
+            requestUpdate.pofThreshold();
+
+            requestUpdate.timerConfigMode();
+            requestUpdate.timerConfigCompare();
+            requestUpdate.timerConfigPrescaler();
+
+            requestUpdate.shipModeTimeToActive();
+            requestUpdate.shipLongPressReset();
+
+            requestUpdate.fuelGauge();
+            requestUpdate.activeBatteryModel();
+            requestUpdate.storedBatteryModel();
+
+            requestUpdate.vbusinCurrentLimiter();
+        },
         ...chargerGet,
 
         ...buckGet,

--- a/src/features/pmicControl/npm/types.ts
+++ b/src/features/pmicControl/npm/types.ts
@@ -416,6 +416,12 @@ export type NpmDevice = {
     getPOFThresholdRange: () => RangeType;
     getUSBCurrentLimiterRange: () => number[];
 
+    chargerDefault: () => Charger;
+    buckDefaults: () => Buck[];
+    ldoDefaults: () => Ldo[];
+    gpioDefaults: () => GPIO[];
+    ledDefaults: () => LED[];
+
     requestUpdate: {
         all: () => void;
         pmicChargingState: () => void;

--- a/src/features/pmicControl/npm/types.ts
+++ b/src/features/pmicControl/npm/types.ts
@@ -417,6 +417,7 @@ export type NpmDevice = {
     getUSBCurrentLimiterRange: () => number[];
 
     requestUpdate: {
+        all: () => void;
         pmicChargingState: () => void;
         chargerVTerm: () => void;
         chargerIChg: () => void;

--- a/src/features/pmicControl/npm/useNpmDevice.tsx
+++ b/src/features/pmicControl/npm/useNpmDevice.tsx
@@ -70,7 +70,7 @@ import {
     DOWNLOAD_BATTERY_PROFILE_DIALOG_ID,
     noop,
 } from './pmicHelpers';
-import { Buck, GPIO, Ldo, LED, LEDModeValues, PmicDialog } from './types';
+import { PmicDialog } from './types';
 
 export default () => {
     const [isPMICPowered, setPMICPowered] = useState(false);
@@ -126,76 +126,13 @@ export default () => {
                 if (!npmDevice) return;
 
                 if (npmDevice.hasCharger()) {
-                    dispatch(
-                        setCharger({
-                            vTerm: npmDevice.getChargerVoltageRange()[0],
-                            vTrickleFast: 2.5,
-                            iChg: npmDevice.getChargerCurrentRange().min,
-                            enabled: false,
-                            iTerm: '10%',
-                            enableRecharging: false,
-                            enableVBatLow: false,
-                            ntcThermistor: '10 kΩ',
-                            ntcBeta: 3380,
-                            tChgStop: 110,
-                            tChgResume: 100,
-                            vTermR: 3.6,
-                            tCold: 0,
-                            tCool: 10,
-                            tWarm: 45,
-                            tHot: 60,
-                        })
-                    );
+                    dispatch(setCharger(npmDevice.chargerDefault()));
                 }
 
-                const emptyBuck: Buck[] = [];
-                for (let i = 0; i < npmDevice.getNumberOfBucks(); i += 1) {
-                    emptyBuck.push({
-                        vOutNormal: npmDevice.getBuckVoltageRange(i).min,
-                        vOutRetention: 1,
-                        mode: 'vSet',
-                        enabled: true,
-                        modeControl: 'Auto',
-                        onOffControl: 'Off',
-                        retentionControl: 'Off',
-                        activeDischarge: false,
-                    });
-                }
-                dispatch(setBucks(emptyBuck));
-
-                const emptyLdos: Ldo[] = [];
-                for (let i = 0; i < npmDevice.getNumberOfLdos(); i += 1) {
-                    emptyLdos.push({
-                        voltage: npmDevice.getLdoVoltageRange(i).min,
-                        mode: 'ldoSwitch',
-                        enabled: false,
-                        softStartEnabled: true,
-                        softStart: 20,
-                        activeDischarge: false,
-                        onOffControl: 'SW',
-                    });
-                }
-                dispatch(setLdos(emptyLdos));
-
-                const emptyGPIOs: GPIO[] = [];
-                for (let i = 0; i < npmDevice.getNumberOfGPIOs(); i += 1) {
-                    emptyGPIOs.push({
-                        mode: 'Input',
-                        pull: 'Pull up',
-                        drive: 1,
-                        openDrain: false,
-                        debounce: false,
-                    });
-                }
-                dispatch(setGPIOs(emptyGPIOs));
-
-                const emptyLEDs: LED[] = [];
-                for (let i = 0; i < npmDevice.getNumberOfLEDs(); i += 1) {
-                    emptyLEDs.push({
-                        mode: LEDModeValues[i],
-                    });
-                }
-                dispatch(setLEDs(emptyLEDs));
+                dispatch(setBucks(npmDevice.buckDefaults()));
+                dispatch(setLdos(npmDevice.ldoDefaults()));
+                dispatch(setGPIOs(npmDevice.gpioDefaults()));
+                dispatch(setLEDs(npmDevice.ledDefaults()));
             };
 
             const releaseAll: (() => void)[] = [];

--- a/src/features/pmicControl/npm/useNpmDevice.tsx
+++ b/src/features/pmicControl/npm/useNpmDevice.tsx
@@ -109,77 +109,7 @@ export default () => {
             pmicState === 'pmic-connected' &&
             supportedVersion
         ) {
-            npmDevice.requestUpdate.usbPowered();
-
-            if (npmDevice.hasCharger()) {
-                npmDevice.requestUpdate.chargerVTerm();
-                npmDevice.requestUpdate.chargerIChg();
-                npmDevice.requestUpdate.chargerEnabled();
-                npmDevice.requestUpdate.chargerVTrickleFast();
-                npmDevice.requestUpdate.chargerITerm();
-                npmDevice.requestUpdate.chargerBatLim();
-                npmDevice.requestUpdate.chargerEnabledRecharging();
-                npmDevice.requestUpdate.chargerEnablevBatLow();
-                npmDevice.requestUpdate.pmicChargingState();
-                npmDevice.requestUpdate.chargerNTCThermistor();
-                npmDevice.requestUpdate.chargerNTCBeta();
-                npmDevice.requestUpdate.chargerTChgStop();
-                npmDevice.requestUpdate.chargerTChgResume();
-                npmDevice.requestUpdate.chargerVTermR();
-                npmDevice.requestUpdate.chargerTCold();
-                npmDevice.requestUpdate.chargerTCool();
-                npmDevice.requestUpdate.chargerTWarm();
-                npmDevice.requestUpdate.chargerTHot();
-            }
-
-            for (let i = 0; i < npmDevice.getNumberOfBucks(); i += 1) {
-                npmDevice.requestUpdate.buckVOutNormal(i);
-                npmDevice.requestUpdate.buckVOutRetention(i);
-                npmDevice.requestUpdate.buckMode(i);
-                npmDevice.requestUpdate.buckEnabled(i);
-                npmDevice.requestUpdate.buckModeControl(i);
-                npmDevice.requestUpdate.buckOnOffControl(i);
-                npmDevice.requestUpdate.buckActiveDischarge(i);
-            }
-
-            for (let i = 0; i < npmDevice.getNumberOfLdos(); i += 1) {
-                npmDevice.requestUpdate.ldoVoltage(i);
-                npmDevice.requestUpdate.ldoMode(i);
-                npmDevice.requestUpdate.ldoEnabled(i);
-                npmDevice.requestUpdate.ldoSoftStartEnabled(i);
-                npmDevice.requestUpdate.ldoSoftStart(i);
-                npmDevice.requestUpdate.ldoActiveDischarge(i);
-                npmDevice.requestUpdate.ldoOnOffControl(i);
-            }
-
-            for (let i = 0; i < npmDevice.getNumberOfGPIOs(); i += 1) {
-                npmDevice.requestUpdate.gpioMode(i);
-                npmDevice.requestUpdate.gpioPull(i);
-                npmDevice.requestUpdate.gpioDrive(i);
-                npmDevice.requestUpdate.gpioOpenDrain(i);
-                npmDevice.requestUpdate.gpioDebounce(i);
-            }
-
-            for (let i = 0; i < npmDevice.getNumberOfLEDs(); i += 1) {
-                npmDevice.requestUpdate.ledMode(i);
-            }
-
-            npmDevice.requestUpdate.pofEnable();
-            npmDevice.requestUpdate.pofPolarity();
-            npmDevice.requestUpdate.pofThreshold();
-
-            npmDevice.requestUpdate.timerConfigMode();
-            npmDevice.requestUpdate.timerConfigCompare();
-            npmDevice.requestUpdate.timerConfigPrescaler();
-
-            npmDevice.requestUpdate.shipModeTimeToActive();
-            npmDevice.requestUpdate.shipLongPressReset();
-
-            npmDevice.requestUpdate.fuelGauge();
-            npmDevice.requestUpdate.activeBatteryModel();
-            npmDevice.requestUpdate.storedBatteryModel();
-
-            npmDevice.requestUpdate.vbusinCurrentLimiter();
+            npmDevice.requestUpdate.all();
 
             npmDevice.getHardcodedBatteryModels().then(models => {
                 dispatch(setHardcodedBatterModels(models));


### PR DESCRIPTION
* Group and move all requestUpdate calls into the pmic1300Device class.
* Add default setting generators inside each subdevice class in the npm1300 tree.
* Update NpmDevice to include the default setting generators
* Use generators from the Init effect