### PR TITLE
Feat/introduce ibat lim low high

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,8 @@
-## 1.2.2 - UNRELEASED
+## 1.3.0 - UNRELEASED
+
+### Added
+
+-   Charger BatLim configuration
 
 ### Changed
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ### Added
 
--   Charger BatLim configuration
+-   Charger Battery Limit (BatLim) configuration.
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pc-nrfconnect-npm",
-    "version": "1.2.2",
+    "version": "1.3.0",
     "description": "Evaluate and implement Nordic's PMICs",
     "displayName": "nPM PowerUP",
     "homepage": "https://github.com/NordicPlayground/pc-nrfconnect-npm",

--- a/src/components/Cards/Power/PowerCard.tsx
+++ b/src/components/Cards/Power/PowerCard.tsx
@@ -158,10 +158,15 @@ export default ({
                                 })),
                             ]}
                             label={
-                                <div>
-                                    <span>IBAT</span>
-                                    <span className="subscript">LIM</span>
-                                </div>
+                                <DocumentationTooltip
+                                    card={card}
+                                    item="IBATLIM"
+                                >
+                                    <div>
+                                        <span>IBAT</span>
+                                        <span className="subscript">LIM</span>
+                                    </div>
+                                </DocumentationTooltip>
                             }
                             disabled={disabled}
                             onSelect={v => npmDevice.setChargerBatLim(v.value)}
@@ -175,10 +180,15 @@ export default ({
                     ) : (
                         <NumberInput
                             label={
-                                <div>
-                                    <span>IBAT</span>
-                                    <span className="subscript">LIM</span>
-                                </div>
+                                <DocumentationTooltip
+                                    card={card}
+                                    item="IBATLIM"
+                                >
+                                    <div>
+                                        <span>IBAT</span>
+                                        <span className="subscript">LIM</span>
+                                    </div>
+                                </DocumentationTooltip>
                             }
                             unit="mA"
                             disabled={disabled}

--- a/src/components/Cards/Power/PowerCard.tsx
+++ b/src/components/Cards/Power/PowerCard.tsx
@@ -16,6 +16,7 @@ import {
 import { DocumentationTooltip } from '../../../features/pmicControl/npm/documentation/documentation';
 import {
     Charger,
+    isFixedListRangeWithLabel,
     ITerm,
     ITermValues,
     NpmDevice,
@@ -55,12 +56,16 @@ export default ({
 
     const [internalVTerm, setInternalVTerm] = useState(charger.vTerm);
     const [internalIChg, setInternalIChg] = useState(charger.iChg);
+    const [internalBatLim, setInternalBatLim] = useState(charger.iBatLim);
 
     // NumberInputSliderWithUnit do not use charger.<prop> as value as we send only at on change complete
     useEffect(() => {
         setInternalVTerm(charger.vTerm);
         setInternalIChg(charger.iChg);
+        setInternalBatLim(charger.iBatLim);
     }, [charger]);
+
+    const chargerIBatLimRange = npmDevice.getChargerIBatLimRange();
 
     return (
         <Card
@@ -131,6 +136,48 @@ export default ({
 
             {!summary && (
                 <>
+                    {isFixedListRangeWithLabel(chargerIBatLimRange) &&
+                    chargerIBatLimRange.toLabel !== undefined ? (
+                        <Dropdown
+                            items={chargerIBatLimRange.map(v => ({
+                                value: v.valueOf(),
+                                label: chargerIBatLimRange.toLabel(v),
+                            }))}
+                            label={
+                                <div>
+                                    <span>IBAT</span>
+                                    <span className="subscript">LIM</span>
+                                </div>
+                            }
+                            disabled={disabled}
+                            onSelect={v => npmDevice.setChargerBatLim(v.value)}
+                            selectedItem={{
+                                value: charger.iBatLim,
+                                label: chargerIBatLimRange.toLabel(
+                                    charger.iBatLim
+                                ),
+                            }}
+                        />
+                    ) : (
+                        <NumberInput
+                            label={
+                                <div>
+                                    <span>IBAT</span>
+                                    <span className="subscript">LIM</span>
+                                </div>
+                            }
+                            unit="mA"
+                            disabled={disabled}
+                            range={npmDevice.getChargerIBatLimRange()}
+                            value={internalBatLim}
+                            onChange={setInternalBatLim}
+                            onChangeComplete={v =>
+                                npmDevice.setChargerBatLim(v)
+                            }
+                            showSlider
+                        />
+                    )}
+
                     <Toggle
                         label={
                             <DocumentationTooltip
@@ -160,7 +207,7 @@ export default ({
                         }
                         isToggled={charger.enableVBatLow}
                         onToggle={value =>
-                            npmDevice.setChargerEnablevBatLow(value)
+                            npmDevice.setChargerEnabledVBatLow(value)
                         }
                         disabled={disabled}
                     />

--- a/src/components/Cards/Power/PowerCard.tsx
+++ b/src/components/Cards/Power/PowerCard.tsx
@@ -182,7 +182,7 @@ export default ({
                             }
                             unit="mA"
                             disabled={disabled}
-                            range={npmDevice.getChargerIBatLimRange()}
+                            range={chargerIBatLimRange}
                             value={internalBatLim}
                             onChange={setInternalBatLim}
                             onChangeComplete={v =>

--- a/src/components/Cards/Power/PowerCard.tsx
+++ b/src/components/Cards/Power/PowerCard.tsx
@@ -139,10 +139,24 @@ export default ({
                     {isFixedListRangeWithLabel(chargerIBatLimRange) &&
                     chargerIBatLimRange.toLabel !== undefined ? (
                         <Dropdown
-                            items={chargerIBatLimRange.map(v => ({
-                                value: v.valueOf(),
-                                label: chargerIBatLimRange.toLabel(v),
-                            }))}
+                            items={[
+                                ...(!chargerIBatLimRange.find(
+                                    v => v === charger.iBatLim
+                                )
+                                    ? [
+                                          {
+                                              value: charger.iBatLim,
+                                              label: chargerIBatLimRange.toLabel(
+                                                  charger.iBatLim
+                                              ),
+                                          },
+                                      ]
+                                    : []),
+                                ...chargerIBatLimRange.map(v => ({
+                                    value: v.valueOf(),
+                                    label: chargerIBatLimRange.toLabel(v),
+                                })),
+                            ]}
                             label={
                                 <div>
                                     <span>IBAT</span>

--- a/src/features/pmicControl/npm/npm1300/charger/chargerCallbacks.ts
+++ b/src/features/pmicControl/npm/npm1300/charger/chargerCallbacks.ts
@@ -213,7 +213,7 @@ export default (
 
                         if (!requested) {
                             console.error(
-                                'unable to parse response. UI might be out of sync'
+                                'Unable to parse response. UI might be out of sync.'
                             );
                             return;
                         }

--- a/src/features/pmicControl/npm/npm1300/charger/index.ts
+++ b/src/features/pmicControl/npm/npm1300/charger/index.ts
@@ -41,7 +41,7 @@ const chargerIBatLimRange = () => {
             case 271:
                 return 'Low';
             default:
-                return 'Manual';
+                return `Manual (${v} mA)`;
         }
     };
 
@@ -113,11 +113,6 @@ export default (
 ) => ({
     chargerGet: chargerGet(sendCommand),
     chargerSet: chargerSet(eventEmitter, sendCommand, offlineMode),
-    chargerCallbacks: chargerCallbacks(
-        shellParser,
-        eventEmitter,
-        sendCommand,
-        offlineMode
-    ),
+    chargerCallbacks: chargerCallbacks(shellParser, eventEmitter),
     chargerRanges: chargerRanges(),
 });

--- a/src/features/pmicControl/npm/npm1300/charger/index.ts
+++ b/src/features/pmicControl/npm/npm1300/charger/index.ts
@@ -18,6 +18,7 @@ export const chargerDefaults = (): Charger => ({
     iChg: chargerCurrentRange.min,
     enabled: false,
     iTerm: '10%',
+    iBatLim: 1340,
     enableRecharging: false,
     enableVBatLow: false,
     ntcThermistor: '10 kΩ',
@@ -30,6 +31,22 @@ export const chargerDefaults = (): Charger => ({
     tWarm: 45,
     tHot: 60,
 });
+
+const chargerIBatLimRange = () => {
+    const result: number[] & { toLabel?: (v: number) => string } = [1340, 271];
+    result.toLabel = (v: number) => {
+        switch (v) {
+            case 1340:
+                return 'High';
+            case 271:
+                return 'Low';
+            default:
+                return 'Manual';
+        }
+    };
+
+    return result;
+};
 
 const chargerVoltageRange = getRange([
     {
@@ -81,6 +98,7 @@ const chargerRanges = () => ({
         decimals: 0,
         step: 1,
     }),
+    getChargerIBatLimRange: chargerIBatLimRange,
 });
 
 export default (
@@ -95,6 +113,11 @@ export default (
 ) => ({
     chargerGet: chargerGet(sendCommand),
     chargerSet: chargerSet(eventEmitter, sendCommand, offlineMode),
-    chargerCallbacks: chargerCallbacks(shellParser, eventEmitter),
+    chargerCallbacks: chargerCallbacks(
+        shellParser,
+        eventEmitter,
+        sendCommand,
+        offlineMode
+    ),
     chargerRanges: chargerRanges(),
 });

--- a/src/features/pmicControl/npm/npm1300/documentationPmic1300.tsx
+++ b/src/features/pmicControl/npm/npm1300/documentationPmic1300.tsx
@@ -824,7 +824,7 @@ export const documentation: Documentation = {
                 content: [
                     <p key="p1">
                         For best fuel gauge accuracy, use
-                        {` `}<span>IBAT</span>{` `}
+                        {` `}<span>IBAT</span>
                         <span className="subscript">LIM_LOW</span> for
                         applications with a lower maximum battery discharge
                         current than 150 mA.

--- a/src/features/pmicControl/npm/npm1300/documentationPmic1300.tsx
+++ b/src/features/pmicControl/npm/npm1300/documentationPmic1300.tsx
@@ -820,19 +820,14 @@ export const documentation: Documentation = {
         ],
         IBATLIM: [
             {
-                title: (
-                    <>
-                        <span>IBAT</span>
-                        <span className="subscript">LIM</span>
-                    </>
-                ),
+                title: <span>Battery Discharge Current Limit</span>,
                 content: [
                     <p key="p1">
-                        For best fuel gauge accuracy it is advised to use
+                        For best fuel gauge accuracy, use
                         <span>IBAT</span>
                         <span className="subscript">LIM_LOW</span> for
                         applications with a lower maximum battery discharge
-                        current than 150mA.
+                        current than 150 mA.
                     </p>,
                 ],
             },

--- a/src/features/pmicControl/npm/npm1300/documentationPmic1300.tsx
+++ b/src/features/pmicControl/npm/npm1300/documentationPmic1300.tsx
@@ -818,6 +818,25 @@ export const documentation: Documentation = {
                 ],
             },
         ],
+        IBATLIM: [
+            {
+                title: (
+                    <>
+                        <span>IBAT</span>
+                        <span className="subscript">LIM</span>
+                    </>
+                ),
+                content: [
+                    <p key="p1">
+                        For best fuel gauge accuracy it is advised to use
+                        <span>IBAT</span>
+                        <span className="subscript">LIM_LOW</span> for
+                        applications with a lower maximum battery discharge
+                        current than 150mA.
+                    </p>,
+                ],
+            },
+        ],
         VTrickleFast: [
             {
                 title: (

--- a/src/features/pmicControl/npm/npm1300/documentationPmic1300.tsx
+++ b/src/features/pmicControl/npm/npm1300/documentationPmic1300.tsx
@@ -824,7 +824,8 @@ export const documentation: Documentation = {
                 content: [
                     <p key="p1">
                         For best fuel gauge accuracy, use
-                        {` `}<span>IBAT</span>
+                        {` `}
+                        <span>IBAT</span>
                         <span className="subscript">LIM_LOW</span> for
                         applications with a lower maximum battery discharge
                         current than 150 mA.

--- a/src/features/pmicControl/npm/npm1300/documentationPmic1300.tsx
+++ b/src/features/pmicControl/npm/npm1300/documentationPmic1300.tsx
@@ -824,7 +824,7 @@ export const documentation: Documentation = {
                 content: [
                     <p key="p1">
                         For best fuel gauge accuracy, use
-                        <span>IBAT</span>
+                        {` `}<span>IBAT</span>{` `}
                         <span className="subscript">LIM_LOW</span> for
                         applications with a lower maximum battery discharge
                         current than 150 mA.

--- a/src/features/pmicControl/npm/npm1300/pmic1300Device.tsx
+++ b/src/features/pmicControl/npm/npm1300/pmic1300Device.tsx
@@ -608,7 +608,7 @@ export const getNPM1300: INpmDevice = (shellParser, dialogHandler) => {
                 requestUpdate.chargerITerm();
                 requestUpdate.chargerBatLim();
                 requestUpdate.chargerEnabledRecharging();
-                requestUpdate.chargerEnablevBatLow();
+                requestUpdate.chargerEnabledVBatLow();
                 requestUpdate.pmicChargingState();
                 requestUpdate.chargerNTCThermistor();
                 requestUpdate.chargerNTCBeta();
@@ -708,10 +708,11 @@ export const getNPM1300: INpmDevice = (shellParser, dialogHandler) => {
                             await chargerSet.setChargerVTerm(charger.vTerm);
                             await chargerSet.setChargerIChg(charger.iChg);
                             await chargerSet.setChargerITerm(charger.iTerm);
+                            await chargerSet.setChargerBatLim(charger.iBatLim);
                             await chargerSet.setChargerEnabledRecharging(
                                 charger.enableRecharging
                             );
-                            await chargerSet.setChargerEnablevBatLow(
+                            await chargerSet.setChargerEnabledVBatLow(
                                 charger.enableVBatLow
                             );
                             await chargerSet.setChargerVTrickleFast(

--- a/src/features/pmicControl/npm/npm1300/tests/commandCallbacks.test.ts
+++ b/src/features/pmicControl/npm/npm1300/tests/commandCallbacks.test.ts
@@ -24,7 +24,6 @@ import {
     USBDetectStatusValues,
 } from '../../types';
 import {
-    helpers,
     PMIC_1300_BUCKS,
     PMIC_1300_GPIOS,
     PMIC_1300_LDOS,
@@ -167,58 +166,6 @@ describe('PMIC 1300 - Command callbacks', () => {
         expect(mockOnChargerUpdate).toBeCalledTimes(1);
         expect(mockOnChargerUpdate).nthCalledWith(1, { iBatLim: 271 });
     });
-
-    test.each(['get', 'set 1000'])(
-        'npmx charger iBatLim closes to High should overwrite ans set it to high %p',
-        async append => {
-            const command = `npmx charger discharging_current ${append}`;
-            const callback =
-                eventHandlers.mockRegisterCommandCallbackHandler(command);
-
-            mockEnqueueRequest.mockImplementation(
-                helpers.registerCommandCallbackSuccess
-            );
-
-            await callback?.onSuccess('Value: 1000mA.', command);
-
-            expect(mockOnChargerUpdate).toBeCalledTimes(2);
-            expect(mockOnChargerUpdate).nthCalledWith(1, { iBatLim: 1000 });
-            expect(mockOnChargerUpdate).nthCalledWith(2, { iBatLim: 1340 });
-            expect(mockEnqueueRequest).nthCalledWith(
-                2,
-                `npmx charger discharging_current set 1340`,
-                expect.anything(),
-                undefined,
-                true
-            );
-        }
-    );
-
-    test.each(['get', 'set 300'])(
-        'npmx charger iBatLim closes to High should overwrite ans set it to low %p',
-        async append => {
-            const command = `npmx charger discharging_current ${append}`;
-            const callback =
-                eventHandlers.mockRegisterCommandCallbackHandler(command);
-
-            mockEnqueueRequest.mockImplementation(
-                helpers.registerCommandCallbackSuccess
-            );
-
-            await callback?.onSuccess('Value: 300mA.', command);
-
-            expect(mockOnChargerUpdate).toBeCalledTimes(2);
-            expect(mockOnChargerUpdate).nthCalledWith(1, { iBatLim: 300 });
-            expect(mockOnChargerUpdate).nthCalledWith(2, { iBatLim: 271 });
-            expect(mockEnqueueRequest).nthCalledWith(
-                2,
-                `npmx charger discharging_current set 271`,
-                expect.anything(),
-                undefined,
-                true
-            );
-        }
-    );
 
     test.each(['get', 'set 100'])('npmx charger die_temp resume %p', append => {
         const command = `npmx charger die_temp resume ${append}`;

--- a/src/features/pmicControl/npm/npm1300/tests/commandCallbacks.test.ts
+++ b/src/features/pmicControl/npm/npm1300/tests/commandCallbacks.test.ts
@@ -24,6 +24,7 @@ import {
     USBDetectStatusValues,
 } from '../../types';
 import {
+    helpers,
     PMIC_1300_BUCKS,
     PMIC_1300_GPIOS,
     PMIC_1300_LDOS,
@@ -141,6 +142,83 @@ describe('PMIC 1300 - Command callbacks', () => {
         expect(mockOnChargerUpdate).toBeCalledTimes(1);
         expect(mockOnChargerUpdate).nthCalledWith(1, { iTerm: '20%' });
     });
+
+    test.each(['get', 'set 1340'])('npmx charger iBatLim %p', append => {
+        const command = `npmx charger discharging_current ${append}`;
+        const callback =
+            eventHandlers.mockRegisterCommandCallbackHandler(command);
+
+        callback?.onSuccess('Value: 1340mA.', command);
+
+        expect(mockOnChargerUpdate).toBeCalledTimes(1);
+        expect(mockOnChargerUpdate).nthCalledWith(1, { iBatLim: 1340 });
+    });
+
+    test('npmx charger iBatLim apx result', () => {
+        const command = `npmx charger discharging_current set 271`;
+        const callback =
+            eventHandlers.mockRegisterCommandCallbackHandler(command);
+
+        callback?.onSuccess(
+            'Info: Requested value was 271 but reading will return 300 due to approximations.',
+            command
+        );
+
+        expect(mockOnChargerUpdate).toBeCalledTimes(1);
+        expect(mockOnChargerUpdate).nthCalledWith(1, { iBatLim: 271 });
+    });
+
+    test.each(['get', 'set 1000'])(
+        'npmx charger iBatLim closes to High should overwrite ans set it to high %p',
+        async append => {
+            const command = `npmx charger discharging_current ${append}`;
+            const callback =
+                eventHandlers.mockRegisterCommandCallbackHandler(command);
+
+            mockEnqueueRequest.mockImplementation(
+                helpers.registerCommandCallbackSuccess
+            );
+
+            await callback?.onSuccess('Value: 1000mA.', command);
+
+            expect(mockOnChargerUpdate).toBeCalledTimes(2);
+            expect(mockOnChargerUpdate).nthCalledWith(1, { iBatLim: 1000 });
+            expect(mockOnChargerUpdate).nthCalledWith(2, { iBatLim: 1340 });
+            expect(mockEnqueueRequest).nthCalledWith(
+                2,
+                `npmx charger discharging_current set 1340`,
+                expect.anything(),
+                undefined,
+                true
+            );
+        }
+    );
+
+    test.each(['get', 'set 300'])(
+        'npmx charger iBatLim closes to High should overwrite ans set it to low %p',
+        async append => {
+            const command = `npmx charger discharging_current ${append}`;
+            const callback =
+                eventHandlers.mockRegisterCommandCallbackHandler(command);
+
+            mockEnqueueRequest.mockImplementation(
+                helpers.registerCommandCallbackSuccess
+            );
+
+            await callback?.onSuccess('Value: 300mA.', command);
+
+            expect(mockOnChargerUpdate).toBeCalledTimes(2);
+            expect(mockOnChargerUpdate).nthCalledWith(1, { iBatLim: 300 });
+            expect(mockOnChargerUpdate).nthCalledWith(2, { iBatLim: 271 });
+            expect(mockEnqueueRequest).nthCalledWith(
+                2,
+                `npmx charger discharging_current set 271`,
+                expect.anything(),
+                undefined,
+                true
+            );
+        }
+    );
 
     test.each(['get', 'set 100'])('npmx charger die_temp resume %p', append => {
         const command = `npmx charger die_temp resume ${append}`;

--- a/src/features/pmicControl/npm/npm1300/tests/exportImport.test.ts
+++ b/src/features/pmicControl/npm/npm1300/tests/exportImport.test.ts
@@ -45,6 +45,7 @@ describe('PMIC 1300 - Apply Config ', () => {
         enableRecharging: true,
         enableVBatLow: false,
         iTerm: '20%',
+        iBatLim: 1340,
         ntcThermistor: '10 kΩ',
         ntcBeta: 3380,
         tChgStop: 10,
@@ -110,6 +111,7 @@ describe('PMIC 1300 - Apply Config ', () => {
             iChg: 32,
             enabled: false,
             iTerm: '10%',
+            iBatLim: 270,
             enableRecharging: false,
             enableVBatLow: false,
             ntcThermistor: '100 kΩ',
@@ -355,7 +357,7 @@ describe('PMIC 1300 - Apply Config ', () => {
 
         expect(gpios).toStrictEqual(sampleConfig.gpios);
 
-        expect(mockOnChargerUpdate).toBeCalledTimes(16);
+        expect(mockOnChargerUpdate).toBeCalledTimes(17);
         expect(mockOnBuckUpdate).toBeCalledTimes(18); // 7 states + 1 (mode change on vOut) * 2 Bucks
         expect(mockOnLdoUpdate).toBeCalledTimes(14);
         expect(mockOnGpioUpdate).toBeCalledTimes(25);

--- a/src/features/pmicControl/npm/npm1300/tests/offlineSetters.test.ts
+++ b/src/features/pmicControl/npm/npm1300/tests/offlineSetters.test.ts
@@ -62,6 +62,13 @@ describe('PMIC 1300 - Setters Offline tests', () => {
         expect(mockOnChargerUpdate).toBeCalledWith({ iTerm: '10%' });
     });
 
+    test('Set setChargerBatLim', async () => {
+        await pmic.setChargerBatLim(1000);
+
+        expect(mockOnChargerUpdate).toBeCalledTimes(1);
+        expect(mockOnChargerUpdate).toBeCalledWith({ iBatLim: 1000 });
+    });
+
     test('Set setChargerEnabledRecharging ', async () => {
         await pmic.setChargerEnabledRecharging(true);
 
@@ -71,8 +78,8 @@ describe('PMIC 1300 - Setters Offline tests', () => {
         });
     });
 
-    test('Set setChargerEnableVBatLow ', async () => {
-        await pmic.setChargerEnablevBatLow(true);
+    test('Set setChargerEnabledBatLow ', async () => {
+        await pmic.setChargerEnabledVBatLow(true);
 
         expect(mockOnChargerUpdate).toBeCalledTimes(1);
         expect(mockOnChargerUpdate).toBeCalledWith({

--- a/src/features/pmicControl/npm/npm1300/tests/requestUpdates.test.ts
+++ b/src/features/pmicControl/npm/npm1300/tests/requestUpdates.test.ts
@@ -119,7 +119,7 @@ describe('PMIC 1300 - Request update commands', () => {
     });
 
     test('Request update chargerEnableVBatLow', () => {
-        pmic.requestUpdate.chargerEnablevBatLow();
+        pmic.requestUpdate.chargerEnabledVBatLow();
 
         expect(mockEnqueueRequest).toBeCalledTimes(1);
         expect(mockEnqueueRequest).toBeCalledWith(

--- a/src/features/pmicControl/npm/npm1300/tests/staticGetters.test.ts
+++ b/src/features/pmicControl/npm/npm1300/tests/staticGetters.test.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
+import { isFixedListRangeWithLabel } from '../../types';
 import { PMIC_1300_BUCKS, PMIC_1300_LDOS, setupMocksBase } from './helpers';
 
 describe('PMIC 1300 - Static getters', () => {
@@ -56,6 +57,18 @@ describe('PMIC 1300 - Static getters', () => {
             decimals: 0,
             step: 2,
         }));
+
+    test('Charger Current Range', () => {
+        const range = pmic.getChargerIBatLimRange();
+
+        expect(isFixedListRangeWithLabel(range)).toBeTruthy();
+        if (isFixedListRangeWithLabel(range)) {
+            expect(range.toLabel?.(1340)).toBe('High');
+            expect(range.toLabel?.(271)).toBe('Low');
+            expect(range.toLabel?.(1000)).toBe('Manual');
+            expect(range.map(v => v.valueOf())).toStrictEqual([1340, 271]);
+        }
+    });
 
     test.each(PMIC_1300_BUCKS)('Buck Voltage Range index: %p', index =>
         expect(pmic.getBuckVoltageRange(index)).toStrictEqual({

--- a/src/features/pmicControl/npm/npm1300/tests/staticGetters.test.ts
+++ b/src/features/pmicControl/npm/npm1300/tests/staticGetters.test.ts
@@ -65,7 +65,7 @@ describe('PMIC 1300 - Static getters', () => {
         if (isFixedListRangeWithLabel(range)) {
             expect(range.toLabel?.(1340)).toBe('High');
             expect(range.toLabel?.(271)).toBe('Low');
-            expect(range.toLabel?.(1000)).toBe('Manual');
+            expect(range.toLabel?.(1000)).toBe('Manual (1000 mA)');
             expect(range.map(v => v.valueOf())).toStrictEqual([1340, 271]);
         }
     });

--- a/src/features/pmicControl/npm/overlay/overlay.ts
+++ b/src/features/pmicControl/npm/overlay/overlay.ts
@@ -57,7 +57,7 @@ npm1300_ek_charger: charger {
     // term-current-percent = <${Number.parseInt(charger.iTerm, 10)}>;
     current-microamp = <${toMicro(charger.iChg / 1000)}>;
     // trickle-microvolt = <${toMicro(charger.vTrickleFast)}>;
-    dischg-limit-microamp = <1000000>;
+    dischg-limit-microamp = <${toMicro(charger.iBatLim / 1000)}>;
     vbus-limit-microamp = <500000>;
     thermistor-ohms = <${thermistorTypeToOverlay(charger.ntcThermistor)}>;
     thermistor-beta = <${charger.ntcBeta}>;

--- a/src/features/pmicControl/npm/types.ts
+++ b/src/features/pmicControl/npm/types.ts
@@ -90,6 +90,7 @@ export type Charger = {
     enableRecharging: boolean;
     enableVBatLow: boolean;
     iTerm: ITerm;
+    iBatLim: number;
     ntcThermistor: NTCThermistor;
     ntcBeta: number;
     tChgStop: number;
@@ -294,6 +295,26 @@ export interface ProfileDownload {
     slot?: number;
 }
 
+export type FixedListRange = number[] | FixedListRangeWithLabel;
+export type FixedListRangeWithLabel = number[] & {
+    toLabel: (value: number) => string;
+};
+
+export type RangeOrFixedListRange = RangeType | FixedListRange;
+
+export const isFixedListRange = (
+    range: RangeOrFixedListRange
+): range is FixedListRange => Array.isArray(range);
+
+export const isFixedListRangeWithLabel = (
+    range: RangeOrFixedListRange
+): range is FixedListRangeWithLabel =>
+    Array.isArray(range) &&
+    (range as FixedListRangeWithLabel).toLabel !== undefined;
+
+export const isRangeType = (range: RangeOrFixedListRange): range is RangeType =>
+    !Array.isArray(range);
+
 export type BaseNpmDevice = {
     kernelReset: () => void;
     getKernelUptime: () => Promise<number>;
@@ -409,6 +430,11 @@ export type NpmDevice = {
     getChargerVTermRRange: () => number[];
     getChargerJeitaRange: () => RangeType;
     getChargerChipThermalRange: () => RangeType;
+    getChargerIBatLimRange: () =>
+        | RangeType
+        | (number[] & {
+              toLabel?: (value: number) => string;
+          });
     getChargerNTCBetaRange: () => RangeType;
     getBuckVoltageRange: (index: number) => RangeType;
     getBuckRetVOutRange: (index: number) => RangeType;
@@ -432,7 +458,7 @@ export type NpmDevice = {
         chargerITerm: () => void;
         chargerBatLim: () => void;
         chargerEnabledRecharging: () => void;
-        chargerEnablevBatLow: () => void;
+        chargerEnabledVBatLow: () => void;
         chargerNTCThermistor: () => void;
         chargerNTCBeta: () => void;
         chargerTChgStop: () => void;
@@ -494,8 +520,9 @@ export type NpmDevice = {
     setChargerEnabled: (state: boolean) => Promise<void>;
     setChargerVTrickleFast: (value: VTrickleFast) => Promise<void>;
     setChargerITerm: (iTerm: ITerm) => Promise<void>;
+    setChargerBatLim: (lim: number) => Promise<void>;
     setChargerEnabledRecharging: (enabled: boolean) => Promise<void>;
-    setChargerEnablevBatLow: (enabled: boolean) => Promise<void>;
+    setChargerEnabledVBatLow: (enabled: boolean) => Promise<void>;
     setChargerNTCThermistor: (
         mode: NTCThermistor,
         autoSetBeta?: boolean


### PR DESCRIPTION
This PR is to address https://nordicsemi.atlassian.net/browse/PMICSW-103 

Summary 

- We only send 1340 or 271 values that are mapped to High and Low
- Keep GUI able to support future cases where we need to have a slider and not dropdown
- overwrite user manual input to the closest value if user has a different value configured.