### PR TITLE
doc: rename app + other edits

### DIFF
--- a/doc/docs/index.md
+++ b/doc/docs/index.md
@@ -1,14 +1,14 @@
-# nRF Connect nPM PowerUP
+# {{app_name}}
 
-nRF Connect nPM PowerUP is a desktop application intended to work with the Power Management Integrated Circuit (PMIC) devices from Nordic Semiconductor to allow customers to quickly and efficiently evaluate the PMIC for their projects.
+The {{app_name}} is a desktop application intended to work with the Power Management Integrated Circuit (PMIC) devices from Nordic Semiconductor to allow customers to quickly and efficiently evaluate the PMIC for their projects.
 
 Once connected to an Evaluation Kit (EK), the app gives full control over the adjustable settings of the PMIC. Using the included battery models, you can also get an estimated time-to-full and time-to-empty when charging or discharging a battery connected to the EK.
 
-nPM PowerUP is installed and updated using [nRF Connect for Desktop](https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/index.html).
+The {{app_name}} is installed and updated using [nRF Connect for Desktop](https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/index.html).
 
 ## Supported devices
 
-nPM PowerUP supports the following Power Management IC devices from Nordic Semiconductor:
+THe {{app_name}} supports the following Power Management IC devices from Nordic Semiconductor:
 
 -   [nPM1300 Evaluation Kit (EK)](https://docs.nordicsemi.com/bundle/ug_npm1300_ek/page/UG/nPM1300_EK/intro.html) - Read [Connect the nPM1300 EK with nPM PowerUP](https://docs.nordicsemi.com/bundle/ug_npm1300_ek/page/UG/nPM1300_EK/use_ek_power_up.html) for information about the hardware setup required to use the nPM1300 EK with nPM PowerUP.
 -   [nPM Fuel Gauge Board](https://docs.nordicsemi.com/bundle/ug_npm_fuel_gauge/page/UG/nPM_fuel_gauge/intro.html) - Read [Connect the nPM1300 EK with the nPM Fuel Gauge Board](https://docs.nordicsemi.com/bundle/nan_045/page/APP/nan_045/battery_profiling.html) for information about the hardware setup required to use the nPM1300 Fuel Gauge Board together with nPM1300 EK and nPM PowerUP.

--- a/doc/docs/installing.md
+++ b/doc/docs/installing.md
@@ -1,3 +1,3 @@
-# Installing nPM PowerUP app
+# Installing the {{app_name}}
 
 For installation instructions, see [Installing nRF Connect for Desktop apps](https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/installing_apps.html) in the nRF Connect for Desktop documentation.

--- a/doc/docs/overview.md
+++ b/doc/docs/overview.md
@@ -42,7 +42,7 @@ This side panel area contains the following buttons:
 | ------------------------ | ----------- |
 | **Export Configuration** | Export the PMIC configuration based on the nPM PowerUP application settings. You can save the configuration to an `.overlay` file for [use in the nRF Connect SDK](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/device_guides/pmic/npm1300.html#importing_an_overlay_from_npm_powerup) or to a JSON file for later use in nPM PowerUP.</br></br>You can also set the configuration before you select a device and export it to a file ([Offline Mode](#offline-mode-actions)). |
 | **Load Configuration**   | Load the PMIC configuration from a JSON file and update all configurations accordingly.</br></br>You can also load a configuration before you select a device ([Offline Mode](#offline-mode-actions)).  |
-| **Open Serial Terminal** | Open the [nRF Connect Serial Terminal](https://docs.nordicsemi.com/bundle/nrf-connect-serial-terminal/page/index.html) application in a separate window. Make sure to first [install the application](). |
+| **Open Serial Terminal** | Open the [Serial Terminal app](https://docs.nordicsemi.com/bundle/nrf-connect-serial-terminal/page/index.html) application in a separate window. Make sure to first [install the application](). |
 | **Reset Device**         | Reset the PMIC device and the nPM Controller. The PMIC default device configuration is restored.  |
 | **Record Events**        | Record all terminal [log](#log) events to CSV files in a selected directory. |
 

--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: nRF Connect nPM PowerUP documentation
+site_name: nPM PowerUP app documentation
 site_url:
 use_directory_urls: false
 
@@ -30,7 +30,7 @@ extra_css:
   - stylesheets/style.css
 
 copyright:
-  Copyright &copy; 2023
+  Copyright &copy; 2023-2024
 
 markdown_extensions:
   - abbr
@@ -42,9 +42,6 @@ markdown_extensions:
   - pymdownx.keys
   - pymdownx.tabbed
   - pymdownx.superfences
-  - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
   - toc:
       permalink: true
       toc_depth: 4
@@ -56,9 +53,10 @@ plugins:
 
 extra:
   test: This is a test abbreviation snippet
+  app_name: nPM PowerUP app
 
 nav:
   - Home: index.md
-  - Installing nPM PowerUP app: installing.md
+  - Installing the nPM PowerUP app: installing.md
   - Overview and user interface: overview.md
   - Profiling a battery with nPM PowerUP: profiling_battery.md

--- a/doc/zoomin/custom.properties
+++ b/doc/zoomin/custom.properties
@@ -1,3 +1,3 @@
 manual.name=nrf-connect-npm
-booktitle=nRF Connect nPM PowerUP
-shortdesc=Documentation for the nRF Connect nPM PowerUP application.
+booktitle=nPM PowerUP app
+shortdesc=Documentation for the nPM PowerUP application.


### PR DESCRIPTION
Dropped nRF Connect from app name.
Updated copyright year.
Removed unused extensions.
Added app_name abbreviation.
NCD-1066.