### PR TITLE
.github: update zoomin.yml to use upload v4

### DIFF
--- a/.github/workflows/zoomin.yml
+++ b/.github/workflows/zoomin.yml
@@ -13,7 +13,7 @@ jobs:
     name: Create Zoomin bundle
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Copy zoomin properties
         run: |

--- a/.github/workflows/zoomin.yml
+++ b/.github/workflows/zoomin.yml
@@ -27,7 +27,7 @@ jobs:
           docs/* mkdocs.yml custom.properties tags.yml
 
       - name: Upload documentation artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: nrf-connect-npm
           path: nrf-connect-npm.zip


### PR DESCRIPTION
Updated zoomin.yml file to actions/upload-artifact@v4. NCD-1100.