### PR TITLE
doc: split documentation for Tau

### DIFF
--- a/doc/docs/evaluating_battery.md
+++ b/doc/docs/evaluating_battery.md
@@ -1,0 +1,15 @@
+# Evaluating a battery model with nPM PowerUP
+
+To start fuel gauge evaluations using a battery model, complete the following steps:
+
+1. Make sure the following conditions are met:
+
+    - You have a battery connected to the EK.
+    - You have the **Fuel Gauge** setting enabled on the [**Dashboard**](./overview.md#dashboard-tab) tab.
+    - For nPM1300: You have an active battery model selected in the [**Fuel Gauge**](./overview.md#fuel-gauge) side panel, either using the **Active Battery Model** for a preloaded battery model or the **Add New Battery Model** > **Custom Model** for your own custom battery model from a JSON file.
+
+1. Open the [**Graph**](./overview.md#graph-tab) tab.
+1. Make sure the **Live** toggle is enabled.</br>
+   The graph will display the live State of Charge over time.
+
+    ![nPM PowerUP graph during real time evaluation](./screenshots/battery_evaluation.png "nPM PowerUP graph during real time evaluation")

--- a/doc/docs/index.md
+++ b/doc/docs/index.md
@@ -8,7 +8,13 @@ The {{app_name}} is installed and updated using [nRF Connect for Desktop](https:
 
 ## Supported devices
 
-THe {{app_name}} supports the following Power Management IC devices from Nordic Semiconductor:
+The {{app_name}} supports the following Power Management IC devices from Nordic Semiconductor:
 
+-   nPM2100 Evaluation Kit (EK)
 -   [nPM1300 Evaluation Kit (EK)](https://docs.nordicsemi.com/bundle/ug_npm1300_ek/page/UG/nPM1300_EK/intro.html) - Read [Connect the nPM1300 EK with nPM PowerUP](https://docs.nordicsemi.com/bundle/ug_npm1300_ek/page/UG/nPM1300_EK/use_ek_power_up.html) for information about the hardware setup required to use the nPM1300 EK with nPM PowerUP.
 -   [nPM Fuel Gauge Board](https://docs.nordicsemi.com/bundle/ug_npm_fuel_gauge/page/UG/nPM_fuel_gauge/intro.html) - Read [Connect the nPM1300 EK with the nPM Fuel Gauge Board](https://docs.nordicsemi.com/bundle/nan_045/page/APP/nan_045/battery_profiling.html) for information about the hardware setup required to use the nPM1300 Fuel Gauge Board together with nPM1300 EK and nPM PowerUP.
+
+!!! note "Note"
+      Some features of the {{app_name}} are only available for specific devices.
+      In the documentation, such features are marked with notes that specify the supported device.
+      When no note is present, the feature is available on all supported devices.

--- a/doc/docs/overview.md
+++ b/doc/docs/overview.md
@@ -1,6 +1,6 @@
 # Overview and user interface
 
-After starting nPM PowerUP, the main application window is displayed.
+After starting the {{app_name}}, the main application window is displayed.
 
 ![nPM PowerUP application window](./screenshots/npm_overview.png "nPM PowerUP application window")
 
@@ -20,7 +20,7 @@ Before a device is selected, the side panel contains the following buttons:
 Dropdown to list the PMIC devices attached to the computer.
 
 !!! note "Note"
-      Read [Connect the nPM1300 EK with nPM PowerUP](https://docs.nordicsemi.com/bundle/ug_npm1300_ek/page/UG/nPM1300_EK/use_ek_power_up.html) for information about the hardware setup required to use the nPM1300 EK with nPM PowerUP.
+      If you are using the nPM1300 EK, read [Connect the nPM1300 EK with nPM PowerUP](https://docs.nordicsemi.com/bundle/ug_npm1300_ek/page/UG/nPM1300_EK/use_ek_power_up.html) for information about the hardware setup required to use this device with the {{app_name}}.
 
 ### Offline mode actions
 
@@ -48,6 +48,9 @@ This side panel area contains the following buttons:
 
 ### Fuel Gauge
 
+!!! note "Note"
+     This feature is available for the nPM1300 EK.
+
 This side panel area lets you select the following options:
 
 |               Menu               | Description |
@@ -55,6 +58,35 @@ This side panel area lets you select the following options:
 | **Active Battery Model**         | Select the battery model you want to use for Fuel Gauge in nPM PowerUP.        |
 | **Add New Active Battery Model** | Select a battery from selected vendors that has been profiled by Nordic Semiconductor or your own custom battery model, added with the **Profile Battery** feature and saved in the [**Profiles**](#profiles-tab) tab.        |
 | **Profile Battery**              | Create your own, custom battery profile, and collect the data. These are then saved in the [**Profiles**](#profiles-tab) tab and added to the **Add New Active Battery Model** drop-down menu.</br></br>An additional board, nPM Fuel Gauge, is required to perform the battery profiling. See [Profiling a battery with nPM PowerUP](profiling_battery.md) for more information.        |
+
+### Power Source
+
+!!! note "Note"
+     This feature is available for the nPM2100 EK.
+
+This side panel area lets you select the power source for nPM2100:
+
+|               Menu               | Description |
+| -------------------------------- | ----------- |
+| **Battery**                      | The default setting. With this power source selected, the application automatically detects the battery type connected to the PMIC. You can also select the battery type from the drop-down menu.        |
+| **USB**                          | Select if you are powering the PMIC from the USB. With this power source selected, the application disables the [**Maximum Energy Extraction**](#maximum-energy-extraction) panel, the **Fuel Gauge** and the **Maximum Energy Extraction** tiles on the [**Dashboard**](#dashboard-tab) tab, and the [**MEE**](#mee-tab) tab, as no battery evaluation is available.        |
+
+
+### Maximum Energy Extraction
+
+!!! note "Note"
+     This feature is available for the nPM2100 EK.
+
+This side panel area lets you select which power profile to use for the Maximum Energy Extraction (MEE) configuration:
+
+|               Menu               | Description |
+| -------------------------------- | ----------- |
+| **Active Power Profile**         | Select a power profile from a list of predefined profiles provided with the application.        |
+| **Add New Active Power Profile** | Add new power profile to the **Active Power Profile** drop-down menu. |
+| **Create & Tune Power Profile**  | Open the [**MEE**](#mee-tab) tab, where you can configure the MEE options. |
+
+!!! note "Note"
+     If you set [**Power Source**](#power-source) to **USB**, this area, the **Fuel Gauge** and the **Maximum Energy Extraction** tiles on the [**Dashboard**](#dashboard-tab) tab, and the [**MEE**](#mee-tab) tab will be unavailable.
 
 ### Settings
 
@@ -77,6 +109,9 @@ The **Dashboard** tab provides a quick look overview of the major PMIC settings 
 
 ## Charger tab
 
+!!! note "Note"
+     This feature is available for the nPM1300 EK.
+
 You can use the options in the **Charger** tab to control and monitor the charging settings and status of the PMIC device.
 
 !!! info "Tip"
@@ -96,9 +131,12 @@ You can use the options in the **GPIOs** tab to configure the GPIO pins availabl
 
 ## System Features tab
 
-You can use the options in the **System Features** tab to configure the **Reset and Low Power control**, **Timer**, **Power Failure**, **Vbus input current limiter**, and **Reset & Error Logs**.
+You can use the options in the **System Features** tab to configure **Reset control**, **Low Power control**, **Timer**, **Power Failure**, **Vbus input current limiter**, and **Reset & Error Logs**.
 
 ## Profiles tab
+
+!!! note "Note"
+     This feature is available for the nPM1300 EK.
 
 The **Profiles** tab provides an overview of all battery profiles that you can select using the [Fuel Gauge drop-down menus](#fuel-gauge).
 
@@ -146,9 +184,16 @@ This can overwrite the [**Active Battery Model**](#fuel-gauge).
 
 When saving, the battery model is saved in the selected directory either to a JSON file that can be downloaded to the nPM Controller or to an INC file. The INC file format is meant for integrating the battery model into your final application with a Nordic System on Chip (SoC).
 
+## MEE tab
+
+!!! note "Note"
+     This feature is available for the nPM2100 EK.
+
+Here you can configure Maximum Energy Extraction options, grouped in **Power Profile** and **Operating Conditions**.
+
 ## Graph tab
 
-Here you can monitor the state of the PMIC, including the current voltage temperature and State of Charge (SOC). For SOC, make sure the battery Fuel Gauge in the **Dashboard** tab or **Fuel Gauge** tab is enabled.
+Here you can monitor the state of the PMIC, including voltage, current, system temperature, internal resistance, and State of Charge (SOC). For SOC, make sure the battery Fuel Gauge in the **Dashboard** tab or **Fuel Gauge** side panel is enabled.
 
 The monitoring can happen in real time after [generating a battery model](profiling_battery.md#generating-a-battery-model). You can use the **Live** toggle to enable or disable real time monitoring.
 

--- a/doc/docs/overview.md
+++ b/doc/docs/overview.md
@@ -69,24 +69,7 @@ This side panel area lets you select the power source for nPM2100:
 |               Menu               | Description |
 | -------------------------------- | ----------- |
 | **Battery**                      | The default setting. With this power source selected, the application automatically detects the battery type connected to the PMIC. You can also select the battery type from the drop-down menu.        |
-| **USB**                          | Select if you are powering the PMIC from the USB. With this power source selected, the application disables the [**Maximum Energy Extraction**](#maximum-energy-extraction) panel, the **Fuel Gauge** and the **Maximum Energy Extraction** tiles on the [**Dashboard**](#dashboard-tab) tab, and the [**MEE**](#mee-tab) tab, as no battery evaluation is available.        |
-
-
-### Maximum Energy Extraction
-
-!!! note "Note"
-     This feature is available for the nPM2100 EK.
-
-This side panel area lets you select which power profile to use for the Maximum Energy Extraction (MEE) configuration:
-
-|               Menu               | Description |
-| -------------------------------- | ----------- |
-| **Active Power Profile**         | Select a power profile from a list of predefined profiles provided with the application.        |
-| **Add New Active Power Profile** | Add new power profile to the **Active Power Profile** drop-down menu. |
-| **Create & Tune Power Profile**  | Open the [**MEE**](#mee-tab) tab, where you can configure the MEE options. |
-
-!!! note "Note"
-     If you set [**Power Source**](#power-source) to **USB**, this area, the **Fuel Gauge** and the **Maximum Energy Extraction** tiles on the [**Dashboard**](#dashboard-tab) tab, and the [**MEE**](#mee-tab) tab will be unavailable.
+| **USB**                          | Select if you are powering the PMIC from the USB. With this power source selected, the application disables the **Fuel Gauge** tile on the [**Dashboard**](#dashboard-tab) tab, as no battery evaluation is available.        |
 
 ### Settings
 
@@ -183,13 +166,6 @@ When writing, you are going to write new battery model on the nPM Controller to 
 This can overwrite the [**Active Battery Model**](#fuel-gauge).
 
 When saving, the battery model is saved in the selected directory either to a JSON file that can be downloaded to the nPM Controller or to an INC file. The INC file format is meant for integrating the battery model into your final application with a Nordic System on Chip (SoC).
-
-## MEE tab
-
-!!! note "Note"
-     This feature is available for the nPM2100 EK.
-
-Here you can configure Maximum Energy Extraction options, grouped in **Power Profile** and **Operating Conditions**.
 
 ## Graph tab
 

--- a/doc/docs/profiling_battery.md
+++ b/doc/docs/profiling_battery.md
@@ -1,11 +1,12 @@
 # Profiling a battery with nPM PowerUP
 
+!!! note "Note"
+     This feature is available for the nPM1300 EK.
+
 Use the nPM PowerUP together with the [nPM1300 Evaluation Kit (EK)](https://docs.nordicsemi.com/bundle/ug_npm1300_ek/page/UG/nPM1300_EK/intro.html) and the [nPM Fuel Gauge Board](https://docs.nordicsemi.com/bundle/ug_npm_fuel_gauge/page/UG/nPM_fuel_gauge/intro.html) to profile your battery and generate a battery model.
 
 The EK and the nPM Fuel Gauge Board are used to profile and generate the model. Once the battery model is extracted, you only need nPM1300 and the SoC (or SiP) in your application to do fuel gauging.
 For the complete overview of the whole process, read the [Using the nPM1300 Fuel Gauge](https://docs.nordicsemi.com/bundle/nan_045/page/APP/nan_045/intro.html) application note.
-
-## Generating a battery model
 
 Complete the following steps to profile a battery and use the generated battery model to initialize and run the nPM1300 fuel gauge in the nPM PowerUP app:
 
@@ -29,19 +30,4 @@ Complete the following steps to profile a battery and use the generated battery 
    A drop-down menu appears.
 1. Select **Custom Model** to load the generated JSON battery model file to the host System on Chip (SoC) of nPM1300 EK.
 
-## Evaluating a battery model
-
-To start fuel gauge evaluations using a battery model, complete the following steps:
-
-1. Make sure the following conditions are met:
-
-    - You have a battery connected to the EK.
-    - You have an active battery model selected in the [**Fuel Gauge**](./overview.md#fuel-gauge) side panel, either using the **Active Battery Model** for a preloaded battery model or the **Add New Battery Model** > **Custom Model** for your own custom battery model from a JSON file.
-    - You have the **Fuel Gauge** setting enabled on the [**Dashboard**](./overview.md#dashboard-tab) tab.
-
-1. Open the [**Graph**](./overview.md#graph-tab) tab.
-1. Make sure the **Live** toggle is enabled.</br>
-   The graph will display the live State of Charge over time.
-
-    ![nPM PowerUP graph during real time evaluation](./screenshots/battery_evaluation.png "nPM PowerUP graph during real time evaluation")
-
+To start fuel gauge evaluations using a battery model, see [Evaluating a battery model with nPM PowerUP](evaluating_battery.md).

--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -59,4 +59,5 @@ nav:
   - Home: index.md
   - Installing the nPM PowerUP app: installing.md
   - Overview and user interface: overview.md
-  - Profiling a battery with nPM PowerUP: profiling_battery.md
+  - Profiling a battery: profiling_battery.md
+  - Evaluating a battery: evaluating_battery.md


### PR DESCRIPTION
Split profiling_battery.md into two pages.
Added notes about features available for specific devices. Updated overview.md with WIP info (TBD sections).
NCD-1113.

---

- [x] Update TBD sections based on the hardware doc
- [x] Call a meeting with Eirik